### PR TITLE
openssl: Support older TLS and DH key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/ruby
 # later in this process)
 ENV PATH="/opt/postal/app/bin:${PATH}"
 
+# Copy and apply openssl.cnf.patch
+COPY ./docker/openssl.cnf.patch /etc/ssl/openssl.cnf.patch
+RUN patch /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf.patch
+
 # Setup an application
 RUN useradd -r -d /opt/postal -m -s /bin/bash -u 999 postal
 USER postal

--- a/docker/openssl.cnf.patch
+++ b/docker/openssl.cnf.patch
@@ -1,22 +1,10 @@
---- /etc/ssl/openssl.cnf	2020-04-20 11:53:50.000000000 +0000
-+++ /etc/ssl/openssl.cnf	2022-03-16 09:28:41.000000000 +0000
-@@ -1,3 +1,5 @@
-+openssl_conf = default_conf
-+
- #
- # OpenSSL example configuration file.
- # This is mostly being used for generation of certificate requests.
-@@ -348,3 +350,13 @@
- 				# (optional, default: no)
- ess_cert_id_alg		= sha1	# algorithm to compute certificate
- 				# identifier (optional, default: sha1)
-+
-+[default_conf]
-+ssl_conf = ssl_sect
-+
-+[ssl_sect]
-+system_default = system_default_sect
-+
-+[system_default_sect]
+--- /etc/ssl/openssl.cnf	2022-03-16 10:01:00.000000000 +0000
++++ /etc/ssl/openssl.cnf	2022-03-16 10:02:00.000000000 +0000
+@@ -358,5 +358,5 @@
+ system_default = system_default_sect
+ 
+ [system_default_sect]
+-MinProtocol = TLSv1.2
+-CipherString = DEFAULT@SECLEVEL=2
 +MinProtocol = TLSv1.0
-+CipherString = DEFAULT:@SECLEVEL=1
++CipherString = DEFAULT@SECLEVEL=1

--- a/docker/openssl.cnf.patch
+++ b/docker/openssl.cnf.patch
@@ -1,0 +1,22 @@
+--- /etc/ssl/openssl.cnf	2020-04-20 11:53:50.000000000 +0000
++++ /etc/ssl/openssl.cnf	2022-03-16 09:28:41.000000000 +0000
+@@ -1,3 +1,5 @@
++openssl_conf = default_conf
++
+ #
+ # OpenSSL example configuration file.
+ # This is mostly being used for generation of certificate requests.
+@@ -348,3 +350,13 @@
+ 				# (optional, default: no)
+ ess_cert_id_alg		= sha1	# algorithm to compute certificate
+ 				# identifier (optional, default: sha1)
++
++[default_conf]
++ssl_conf = ssl_sect
++
++[ssl_sect]
++system_default = system_default_sect
++
++[system_default_sect]
++MinProtocol = TLSv1.0
++CipherString = DEFAULT:@SECLEVEL=1


### PR DESCRIPTION
dragoangel commented on 16 Mar
> Due to SMTP is much less optimistic in terms of new encryption standards and due to fallback to plaintext - better to have TLSv1.0 then plaintext. Small DH key at this time work as DoS at all.

thanks dragoangel!